### PR TITLE
Spec correctness updates based on review feedback

### DIFF
--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -164,9 +164,10 @@
       </p> 
       <dl> 
         <dt>Payment Request Document Architecture</dt>
-        <dd>The terms <dfn data-lt="payment method|payment methods">Payment Method</dfn> and
-        <dfn data-lt="payment app|payment apps">Payment App</dfn> are defined by the Payment Request
-        Architecture document [[PAYMENTARCH]].</dd>
+        <dd>The terms <dfn data-lt="payment method|payment methods">Payment Method</dfn>,
+        <dfn data-lt="payment app|payment apps">Payment App</dfn>, and <dfn>Payment Transaction
+        Message Specification</dfn> are defined by the Payment Request Architecture document
+        [[PAYMENTARCH]].</dd>
         <dt>Payment Request Document Architecture</dt>
         <dd>The term <dfn data-lt="payment method identifier|payment method identifiers">Payment
         Method Identifier</dfn> is defined by the Payment Method Identifiers specification
@@ -249,7 +250,7 @@
 
       <pre class="example highlight">
 var payment = new PaymentRequest(supportedMethods, details, options, data);
-payment.addEventListener("shippingAddressChange", function (changeEvent) {
+payment.addEventListener("shippingaddresschange", function (changeEvent) {
     // Process shipping address change
 });
 
@@ -299,27 +300,27 @@ payment.show().then(function(paymentResponse) {
             }
           </pre>
 
+          <p>The <code>options</code> object contains information about what options the web page
+          wishes to use from the payment request system.</p>
+
           <pre class="example highlight">
             {
               "requestShipping": true
             }
           </pre>
 
-          <p>The <code>options</code> object contains information about what options the web page
-          wishes to use from the payment request system.</p>
-
           <p><code>data</code> is a <a>JSON object</a> that provides optional information that might
           be needed by the supported <a>payment methods</a>.</p>
           <pre class="example highlight">
-{
-  "bobpay.com": {
-      "merchantIdentifier": "XXXX",
-      "bobPaySpecificField": true
-  },
-  "bitcoin": {
-      "address": "XXXX"
-  }
-}
+            {
+              "bobpay.com": {
+                  "merchantIdentifier": "XXXX",
+                  "bobPaySpecificField": true
+              },
+              "bitcoin": {
+                  "address": "XXXX"
+              }
+            }
           </pre>
         </div>
 
@@ -401,10 +402,6 @@ payment.show().then(function(paymentResponse) {
             than zero, then <a>throw</a> an <a><code>InvalidAccessError</code></a>.
           </li>
           <li>
-            If <em>options</em> does not contain a value for <code>requestShipping</code> then set
-            the value for <code>requestShipping</code> on <em>options</em> to <code>false</code>.
-          </li>
-          <li>
             If <em>data</em> is not a JSON object, then <a>throw</a> an <a><code>InvalidAccessError</code></a>.
           </li>
           <li>
@@ -482,7 +479,7 @@ payment.show().then(function(paymentResponse) {
       <section>
         <h2>shippingAddress</h2>
         <p>
-          <code><dfn>shippingAddress</dfn></code> is populated when the user provides a shipping
+          <code>shippingAddress</code> is populated when the user provides a shipping
           address. It is <em>null</em> by default.
           When a user provides a shipping address, the <a>shipping address changed algorithm</a> runs.
         </p>
@@ -495,7 +492,7 @@ payment.show().then(function(paymentResponse) {
       <section>
         <h2>shippingOption</h2>
         <p>
-          <code><dfn>shippingOption</dfn></code> is populated when the user chooses a shipping
+          <code>shippingOption</code> is populated when the user chooses a shipping
           option. It is <em>null</em> by default.
           When a user chooses a shipping option, the <a>shipping option changed algorithm</a> runs.
         </p>
@@ -515,8 +512,8 @@ payment.show().then(function(paymentResponse) {
       <h2>CurrencyAmount</h2>
       <pre class="idl">
 dictionary CurrencyAmount {
-  DOMString currencyCode;
-  DOMString value;
+  required DOMString currencyCode;
+  required DOMString value;
 };
       </pre>
       <p>
@@ -532,7 +529,7 @@ dictionary CurrencyAmount {
         <dt><code><dfn>value</dfn></code></dt>
         <dd>
           A string containing the decimal monetary value. The string MUST use a single U+002E FULL
-          STOP character as the decimal separator. The string MUST begin with a sing U+002D HYPHEN-MINUS
+          STOP character as the decimal separator. The string MUST begin with a single U+002D HYPHEN-MINUS
           character if the value is negative. All other characters must be characters in the range
           U+0030 DIGIT ZERO (0) to U+0039 DIGIT NINE (9).
           <div class="note">
@@ -594,7 +591,7 @@ dictionary PaymentDetails {
       <h2>PaymentOptions dictionary</h2>
       <pre class="idl">
 dictionary PaymentOptions {
-  boolean requestShipping;
+  boolean requestShipping = false;
 };
       </pre>
 
@@ -622,9 +619,9 @@ dictionary PaymentOptions {
       <h2>PaymentItem dictionary</h2>
       <pre class="idl">
         dictionary PaymentItem {
-          string id;
-          string label;
-          CurrencyAmount amount;
+          required DOMString id;
+          required DOMString label;
+          required CurrencyAmount amount;
           boolean shipping;
         };
       </pre>
@@ -657,8 +654,8 @@ dictionary PaymentOptions {
       </p>
       <dl>
         <dt><code>shipping</code></dt>
-        <dd>If the <code>shipping</code> field is included, then it indicates whether this
-        item represents the shipping cost when set to <code>true</code>. The <a>user agent</a>
+        <dd>If the <code>shipping</code> field is included and set to <code>true</code>, then
+        this indicates that the item is the cost of shipping. The <a>user agent</a>
         MAY use this value to display the item differently in the user interface, perhaps
         relating it to the available shipping options.</dd>
       </dl>
@@ -672,7 +669,7 @@ dictionary PaymentOptions {
         };
       </pre>
       <p>
-        If the <a>requestShipping</a> flag was set to <code>true</code> in the <a>PaymentDetails</a>
+        If the <a>requestShipping</a> flag was set to <code>true</code> in the <a>PaymentOptions</a>
         passed to the <a>PaymentRequest</a> constructor, then the <a>user agent</a> will populate the
         <code>shippingAddress</code> field of the <a><code>PaymentRequest</code></a> object with
         the user's selected shipping address.
@@ -886,7 +883,7 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
           <li>Set the <em>updating</em> flag on <em>request</em> to <em>true</em>.</li>
           <li>
             The <a>user agent</a> SHOULD disable the user interface that allows the user to accept
-            the payment request. This is to ensure that they payment is not accepted until the web page
+            the payment request. This is to ensure that the payment is not accepted until the web page
             has made changes required by the change. The web page MUST call <a><code>updatePaymentRequest</code></a>
             (even with no changes) to indicate that the payment request is valid again.
             <p>The <a>user agent</a> SHOULD disable any part of the user interface that could cause
@@ -991,7 +988,8 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
           <li>
             Set the <code>details</code> attribute value of <em>response</em> to a <a>JSON object</a>
             containing the <a>payment method</a> specific message used by the merchant to process
-            the transaction.
+            the transaction. The format of this response will be defined by a <a>Payment Transaction
+            Message Specification</a>.
           </li>
           <li>
             Set the <a><code>state</code></a> of <em>request</em> to <code>accepted</code>.

--- a/specs/paymentrequest.html
+++ b/specs/paymentrequest.html
@@ -178,8 +178,10 @@
         <dfn>top-level browsing context</dfn> are defined by [[!HTML5]].</dd>
         <dt>ECMA-262 6th Edition, The ECMAScript 2015 Language Specification</dt>
         <dd>
-          The terms <dfn>Promise</dfn>, <dfn>JSON.stringify</dfn>, and <dfn>JSON.parse</dfn> are
+          The terms <dfn>Promise</dfn>, <dfn>internal slot</dfn>, <dfn>JSON.stringify</dfn>, and <dfn>JSON.parse</dfn> are
           defined by [[!ECMA-262-2015]].
+          <p>This document uses the format <em>object</em>@[[\slotname]] to mean the internal slot [[\slotname]]
+          of the object <em>object</em>.</p>
           <p>The term <dfn>JSON object</dfn> used in this specification means an object that can
           be serialized to a string using <a>JSON.stringify</a> and later deserialized back to an object
           using <a>JSON.parse</a> with no loss of data.</p>
@@ -211,21 +213,11 @@
     <section>
       <h2>PaymentRequest interface</h2>
       <pre class="idl">
-        enum PaymentRequestState {
-          "created",
-          "interactive",
-          "delegated",
-          "accepted",
-          "closed"
-        };
-
         [Constructor(sequence&lt;DOMString&gt; supportedMethods, PaymentDetails details, optional PaymentOptions options, optional object data)]
         interface PaymentRequest : EventTarget {
           Promise&lt;PaymentResponse&gt; show();
           void complete(boolean success);
           void abort();
-
-          readonly attribute PaymentRequestState state;
 
           readonly attribute ShippingAddress? shippingAddress;
           readonly attribute DOMString? shippingOption;
@@ -249,17 +241,19 @@
       user interaction:</p>
 
       <pre class="example highlight">
-var payment = new PaymentRequest(supportedMethods, details, options, data);
-payment.addEventListener("shippingaddresschange", function (changeEvent) {
-    // Process shipping address change
-});
+        var payment = new PaymentRequest(supportedMethods, details, options, data);
+        payment.addEventListener("shippingaddresschange", function (changeEvent) {
+            // Process shipping address change
+        });
 
-payment.show().then(function(paymentResponse) {
-  // Process paymentResponse
-  payment.complete(true);
-}).catch(function(err) {
-  console.error("Uh oh, something bad happened", err.message);
-});
+        payment.show().then(function(paymentResponse) {
+          // Process paymentResponse
+          // paymentResponse.methodName contains the selected payment method
+          // paymentResponse.details contains a payment method specific response
+          payment.complete(true);
+        }).catch(function(err) {
+          console.error("Uh oh, something bad happened", err.message);
+        });
       </pre>
 
       <section>
@@ -349,29 +343,18 @@ payment.show().then(function(paymentResponse) {
             </div>
           </li>
           <li>Let <em>request</em> be a new <a><code>PaymentRequest</code></a>.</li>
-          <li>
-            <p>Let <em>supportedMethods</em> be a structured clone of <code>supportedMethods</code>.</p>
-            <p>Let <em>details</em> be a structured clone of <code>details</code>.</p>
-            <p>If <code>options</code> is provided, then let <em>options</em> be a structured clone
-            of <code>options</code>, else let <em>options</em> be an empty dictionary.</p>
-            <p>If <code>data</code> is provided, then let <em>data</em> be a structured clone
-            of <code>data</code>, else let <em>data</em> be an empty dictionary.</p>
-          </li>
-          <li>
-            Store <em>supportedMethods</em>, <em>details</em>, <em>options</em> and <em>data</em> in the
-            internal state of <em>request</em>.
-          </li>
-          <li>Set the value of the <a><code>state</code></a> attribute on <em>request</em> to <code>created</code>.</li>
+          <li>Store <code>supportedMethods</code> into <em>request</em>@[[\supportedMethods]].</li>
+          <li>Store <code>details</code> into <em>request</em>@[[\details]].</li>
+          <li>Store <code>options</code> into <em>request</em>@[[\options]].</li>
+          <li>Store <code>data</code> into <em>request</em>@[[\data]].</li>
+          <li>Set the value <em>request</em>@[[\state]] to <em>created</em>.</li>
           <li>
             Set the value of the <a><code>shippingAddress</code></a> attribute on <em>request</em> to <em>null</em>.
           </li>
           <li>
             Set the value of the <a><code>shippingOption</code></a> attribute on <em>request</em> to <em>null</em>.
           </li>
-          <li>
-            Set the value of an internal flag on <em>request</em> called <em>updating</em>
-            to <em>false</em>.
-          </li>
+          <li>Set the value <em>request</em>@[[\updating]] to <em>false</em>.</li>
           <li>Return <em>request</em>.</li>
         </ol>
       </section>
@@ -392,41 +375,42 @@ payment.show().then(function(paymentResponse) {
           <li>
             Let <em>request</em> be the <a><code>PaymentRequest</code></a> object on which the method is called..
           </li>
-          <li>If the value of the <a><code>state</code></a> attribute on <em>request</em> is not <code>created</code> then
+          <li>If the value of <em>request</em>@[[\state]] is not <em>created</em> then
           <a>throw</a> an <a><code>InvalidStateError</code></a>.</li>
           <li>
-            Set the value of the <a><code>state</code></a> attribute on <em>request</em> be <code>interactive</code>.
+            Set the value of <em>request</em>@[[\state]] to <em>interactive</em>.
           </li>
           <li>
-            If <em>details</em> does not contain a sequence of <code>items</code> with length greater
+            If <em>request</em>@[[\details]] does not contain a sequence of <code>items</code> with length greater
             than zero, then <a>throw</a> an <a><code>InvalidAccessError</code></a>.
           </li>
           <li>
-            If <em>data</em> is not a JSON object, then <a>throw</a> an <a><code>InvalidAccessError</code></a>.
+            If <em>request</em>@[[\data]] is not a JSON object, then <a>throw</a> an <a><code>InvalidAccessError</code></a>.
           </li>
           <li>
-            The name of each top level field of <em>data</em> MUST match a <a>payment method identifier</a>
-            in <em>supportedMethods</em>. The value of each top level field MUST be a <a>JSON object</a>.
+            The name of each top level field of <em>request</em>@[[\data]] MUST match a <a>payment method identifier</a>
+            in <em>request</em>@[[\supportedMethods]]. The value of each top level field MUST be a <a>JSON object</a>.
             If this is not the case, then <a>throw</a> an <a><code>InvalidAccessError</code></a>.
           </li>
           <li>
-            Let <dfn>acceptPromise</dfn> be a new <a>Promise</a>.
+            Let <em>acceptPromise</em> be a new <a>Promise</a>.
           </li>
           <li>
-            Store <em>acceptPromise</em> in the internal state of <em>request</em>.
+            Store <em>acceptPromise</em> in <em>request</em>@[[\acceptPromise]].
           </li>
           <li>
             Return <em>acceptPromise</em> and asynchronously perform the remaining steps.
           </li>
           <li>
-            Let <em>acceptedMethods</em> be the sequence of payment method identifiers <em>supportedMethods</em>
+            Let <em>acceptedMethods</em> be the sequence of payment method identifiers <em>request</em>@[[\supportedMethods]]
             with all identifiers removed that the <a>user agent</a> does not accept.
           </li>
           <li>
             If the length of <em>acceptedMethods</em> is zero, then reject <em>acceptPromise</em> with a <a><code>NotSupportedError</code></a>.
           </li>
           <li>
-            Show a user interface to allow the user to interact with the payment request process.
+            Show a user interface to allow the user to interact with the payment request process. The <em>acceptPromise</em> will
+            later be resolved by the <a>user accepts the payment request algorithm</a> through interaction with the user interface.
           </li>
         </ol>
       </section>
@@ -434,16 +418,16 @@ payment.show().then(function(paymentResponse) {
       <section>
         <h2>complete()</h2>
         <p>The <code><dfn>complete</dfn></code> method must be called after the user has accepted the payment
-        request and the <a><em>acceptPromise</em></a> has been resolved. The <code>complete</code> method
+        request and the [[\acceptPromise]] has been resolved. The <code>complete</code> method
         takes a boolean argument that indicates the payment was successfully processed if <code>true</code> and
         that processing failed if <code>false</code>. Calling the <code>complete</code> method tells the user
         agent that the user interaction is over (and should cause any remaining user interface to be closed).</p>
 
         <p>The <a><code>complete</code></a> method MUST act as follows:</p>
         <ol>
-          <li>If the value of the <a><code>state</code></a> attribute is not <code>accepted</code> then
+          <li>If the value of the [[\state]] is not <em>accepted</em> then
           <a>throw</a> an <a><code>InvalidStateError</code></a>.</li>
-          <li>Set the value of the <a><code>state</code></a> attribute to <code>closed</code>.</li>
+          <li>Set the value of the internal slot [[\state]] to <em>closed</em>.</li>
           <li>Return from the method and asynchronously perform the remaining steps.</li>
           <li>Close down any remaining user interface</li>
         </ol>
@@ -452,26 +436,23 @@ payment.show().then(function(paymentResponse) {
       <section>
         <h2>abort()</h2>
         <p>The <code><dfn>abort</dfn></code> method may be called if the web page wishes to abort the payment
-        request after the <a><code>show</code></a> method has been called and before the <a><em>acceptPromise</em></a>
+        request after the <a><code>show</code></a> method has been called and before the [[\acceptPromise]]
         has been resolved.</p>
 
         <p>The <a><code>abort</code></a> method MUST act as follows:</p>
         <ol>
-          <li>If the value of the <a><code>state</code></a> attribute is not <code>interactive</code> then
+          <li>If the value of [[\state]] is not <em>interactive</em> then
           <a>throw</a> an <a><code>InvalidStateError</code></a>.</li>
-          <li>Set the value of the <a><code>state</code></a> attribute to <code>closed</code>.</li>
+          <li>Set the value of the internal slot [[\state]] to <em>closed</em>.</li>
           <li>Return from the method and asynchronously perform the remaining steps.</li>
           <li>Abort the current user interaction and close down any remaining user interface</li>
         </ol>
       </section>
 
       <section>
-        <h2>state</h2>
-        <p>The <code><dfn>state</dfn></code> attribute indicates the current state of the <a><code>PaymentRequest</code></a>
-        object</p>
-
+        <h2>State transitions</h2>
         <div class="note">
-          <p>The <a><code>state</code></a> attribute follows the following state transitions:</p>
+          <p>The internal slot [[\state]] follows the following state transitions:</p>
           <img src="state-transitions.svg" width="758" height="235">
         </div>
       </section>
@@ -786,29 +767,29 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
             the event.
           </li>
           <li>
-            If the <em>updating</em> flag on <em>target</em> is <em>false</em>, then <a>throw</a>
+            If <em>target</em>@[[\updating]] is <em>false</em>, then <a>throw</a>
             an <a><code>InvalidStateError</code></a>.
           </li>
           <li>
-            If the <a><code>state</code></a> of <em>target</em> is not <code>interactive</code>,
+            If <em>target</em>@[[\state]] is not <em>interactive</em>,
             then <a>throw</a> an <a><code>InvalidStateError</code></a>. Note: it should not be
-            possible for this to occur since <em>updating</em> should only ever be <em>true</em>
-            when the <code>state</code> is <code>interactive</code>.
+            possible for this to occur since [[\updating]] should only ever be <em>true</em>
+            when the [[\state]] is <em>interactive</em>.
           </li>
           <li>
             If the <code>details</code> argument contains an <code>items</code> value, then copy
-            this value to the <code>items</code> field of the <em>details</em> object on <em>target</em>.
+            this value to the <code>items</code> field of <em>target</em>@[[\details]].
           </li>
           <li>
             If the <code>details</code> argument contains a <code>shippingOptions</code> value, then
             copy this value to the <em>shippingOptions</em> of the <em>target</em>.
           </li>
           <li>
-            Set the <em>updating</em> flag on <em>target</em> to <em>false</em>.
+            Set <em>target</em>@[[\updating]] to <em>false</em>.
           </li>
           <li>
             The method should return and the <a>user agent</a> should asynchronously update the
-            user interface based on the changed values in <em>details</em>.
+            user interface based on the changed values in <em>target</em>@[[\details]].
           </li>
         </ol>
 
@@ -818,8 +799,9 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
     <section>
       <h2>Algorithms</h2>
 
-      <p>When the <a><code>PaymentRequest</code></a> object is in the <code>interactive</code> state,
-      the <a>user agent</a> will trigger the following algorithms based on user interaction.</p>
+      <p>When the internal slot [[\state]] of a <a><code>PaymentRequest</code></a> object is set to
+      <em>interactive</em>, the <a>user agent</a> will trigger the following algorithms based
+      on user interaction.</p>
 
       <section>
         <h2>Shipping address changed algorithm</h2>
@@ -870,17 +852,17 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
         <p>It MUST run the following steps:</p> 
         <ol>
           <li>
-            If the <em>updating</em> flag on <em>request</em> is <em>true</em>, then terminate
+            If the <em>request</em>@[[\updating]] is <em>true</em>, then terminate
             this algorithm and take no further action. Only one update may take place at a time. This
             should never occur.
           </li>
           <li>
-            If the <a><code>state</code></a> of <em>request</em> is not set to <code>interactive</code>,
+            If the <em>request</em>@[[\state]] is not set to <em>interactive</em>,
             then terminate this algorithm and take no further action. The <a>user agent</a> user interface
             should ensure that this never occurs.
           </li>
           <li>Let <em>event</em> be a new <a><code>PaymentRequestUpdateEvent</code></a>.</li>
-          <li>Set the <em>updating</em> flag on <em>request</em> to <em>true</em>.</li>
+          <li>Set <em>request</em>@[[\updating]] to <em>true</em>.</li>
           <li>
             The <a>user agent</a> SHOULD disable the user interface that allows the user to accept
             the payment request. This is to ensure that the payment is not accepted until the web page
@@ -889,7 +871,7 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
             <p>The <a>user agent</a> SHOULD disable any part of the user interface that could cause
             another update event to be fired. Only one update may be processed at a time.</p>
             <div class="issue" title="Consider adding a timeout to the updating flag in case page doesn't call updatePaymentRequest">
-              We should add a timeout mechanism that sets <em>updating</em> to <em>false</em> if the
+              We should add a timeout mechanism that sets [[\updating]] to <em>false</em> if the
               page doesn't call <a><code>updatePaymentRequest</code></a> within a reasonable time.
             </div>
           </li>
@@ -923,17 +905,17 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
             interacting with.
           </li>
           <li>
-            If the <em>updating</em> flag on <em>request</em> is <em>true</em>, then terminate this
+            If the <em>request</em>@[[\updating]] is <em>true</em>, then terminate this
             algorithm and take no further action. The <a>user agent</a> user interface should ensure
             that this never occurs.
           </li>
           <li>
-            If the <a><code>state</code></a> of <em>request</em> is not <code>interactive</code>,
-            then terminate this algorithm and take no further action. The <a>user agent</a> user
-            interface should ensure that this never occurs.
+            If the <em>request</em>@[[\state]] is not <em>interactive</em>, then terminate this
+            algorithm and take no further action. The <a>user agent</a> user interface should ensure
+            that this never occurs.
           </li>
           <li>
-            Set the <a><code>state</code></a> of <em>request</em> to <code>delegated</code>.
+            Set <em>request</em>@[[\state]] to <em>delegated</em>.
           </li>
         </ol>
 
@@ -962,17 +944,17 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
             interacting with.
           </li>
           <li>
-            If the <em>updating</em> flag on <em>request</em> is <em>true</em>, then terminate this
+            If the <em>request</em>@[[\updating]] is <em>true</em>, then terminate this
             algorithm and take no further action. The <a>user agent</a> user interface should ensure
             that this never occurs.
           </li>
           <li>
-            If the <a><code>state</code></a> of <em>request</em> is not <code>interactive</code> and
+            If <em>request</em>@[[\state]] is not <em>interactive</em> and
             the not <code>delegated</code>, then terminate this algorithm and take no further action.
             The <a>user agent</a> user interface should ensure that this never occurs.
           </li>
           <li>
-            If the <code>requestShipping</code> value of <em>options</em> stored in <em>request</em>
+            If the <code>requestShipping</code> value of <em>request</em>@[[\options]]
             is <code>true</code>, then if the <code>shippingAddress</code> attribute of <em>request</em>
             is <code>null</code> or if the <code>shippingOption</code> attribute of <em>request</em>
             is <code>null</code>, then terminate this algorithm and take no further action. This should
@@ -992,11 +974,10 @@ dictionary PaymentRequestUpdateEventInit : EventInit {
             Message Specification</a>.
           </li>
           <li>
-            Set the <a><code>state</code></a> of <em>request</em> to <code>accepted</code>.
+            Set <em>request</em>@[[\state]] to <em>accepted</em>.
           </li>
           <li>
-            Resolve the pending <a><em>acceptPromise</em></a> for the <em>request</em> that was returned
-            by the <a><code>show</code></a> method call that started the payment request.
+            Resolve the pending promise <em>request</em>@[[\acceptPromise]].
           </li>
         </ol>
       </section>


### PR DESCRIPTION
@travisleithead reviewed the spec against the API design guidelines and for correctness and gave me a list of feedback to use correct specification structure and language. Some of the language in the spec was already either handled in WebIDL (e.g. structured clone of dictionary is implied) or better reflected with WebIDL (e.g. using default values in dictionaries). Internal data is now described using internal slots.